### PR TITLE
Bits: Add fromBytes

### DIFF
--- a/source/niknaks/bits.d
+++ b/source/niknaks/bits.d
@@ -213,7 +213,7 @@ unittest
 }
 
 
-public T fromBytes(T)(ubyte[] bytes) if(__traits(isIntegral, T))
+public T bytesToIntegral(T)(ubyte[] bytes) if(__traits(isIntegral, T))
 {
     T value = *cast(T*)bytes.ptr;
     return value;
@@ -224,13 +224,13 @@ unittest
     version(LittleEndian)
     {
         ubyte[] bytes = [1, 0];
-        ushort to = fromBytes!(ushort)(bytes);
+        ushort to = bytesToIntegral!(ushort)(bytes);
         assert(to == 1);
     }
     else version(BigEndian)
     {
         ubyte[] bytes = [1, 0];
-        ushort to = fromBytes!(ushort)(bytes);
+        ushort to = bytesToIntegral!(ushort)(bytes);
         assert(to == 256);
     }
 }

--- a/source/niknaks/bits.d
+++ b/source/niknaks/bits.d
@@ -211,3 +211,26 @@ unittest
         assert(bytes == [0, 0, 0, 0, 0, 0, 0, 1]);
     }
 }
+
+
+public T fromBytes(T)(ubyte[] bytes) if(__traits(isIntegral, T))
+{
+    T value = *cast(T*)bytes.ptr;
+    return value;
+}
+
+unittest
+{
+    version(LittleEndian)
+    {
+        ubyte[] bytes = [1, 0];
+        ushort to = fromBytes!(ushort)(bytes);
+        assert(to == 1);
+    }
+    else version(BigEndian)
+    {
+        ubyte[] bytes = [1, 0];
+        ushort to = fromBytes!(ushort)(bytes);
+        assert(to == 256);
+    }
+}

--- a/source/niknaks/bits.d
+++ b/source/niknaks/bits.d
@@ -212,10 +212,26 @@ unittest
     }
 }
 
-
+/** 
+ * Takes an array of bytes and dereferences
+ * then to an integral of your choosing
+ *
+ * Params:
+ *   T = the integral type to go to
+ *   bytes = the bytes to copy
+ * Returns: the integral but `0` if the
+ * provided size would cause a overrun
+ * read
+ */
 public T bytesToIntegral(T)(ubyte[] bytes) if(__traits(isIntegral, T))
 {
-    T value = *cast(T*)bytes.ptr;
+    T value = 0;
+    
+    if(bytes.length >= T.sizeof)
+    {
+        value = *cast(T*)bytes.ptr;
+    }
+
     return value;
 }
 

--- a/source/niknaks/bits.d
+++ b/source/niknaks/bits.d
@@ -274,12 +274,12 @@ unittest
     {
         ubyte[] bytes = [1];
         ushort to = bytesToIntegral!(ushort)(bytes);
-        assert(to == 0);
+        assert(to == ushort.init);
     }
     else version(BigEndian)
     {
         ubyte[] bytes = [1];
         ushort to = bytesToIntegral!(ushort)(bytes);
-        assert(to == 0);
+        assert(to == ushort.init);
     }
 }

--- a/source/niknaks/bits.d
+++ b/source/niknaks/bits.d
@@ -226,7 +226,7 @@ unittest
 public T bytesToIntegral(T)(ubyte[] bytes) if(__traits(isIntegral, T))
 {
     T value = 0;
-    
+
     if(bytes.length >= T.sizeof)
     {
         value = *cast(T*)bytes.ptr;
@@ -235,6 +235,14 @@ public T bytesToIntegral(T)(ubyte[] bytes) if(__traits(isIntegral, T))
     return value;
 }
 
+/**
+ * Tests taking a byte array and then
+ * decoding it into the requested type
+ * by using `bytesToIntegral!(T)(ubyte[])`
+ *
+ * In this case provided bytes match the
+ * given integral to-type
+ */
 unittest
 {
     version(LittleEndian)

--- a/source/niknaks/bits.d
+++ b/source/niknaks/bits.d
@@ -219,13 +219,13 @@ unittest
  * Params:
  *   T = the integral type to go to
  *   bytes = the bytes to copy
- * Returns: the integral but `0` if the
- * provided size would cause a overrun
+ * Returns: the integral but `T.init` if
+ * the provided size would cause an overrun
  * read
  */
 public T bytesToIntegral(T)(ubyte[] bytes) if(__traits(isIntegral, T))
 {
-    T value = 0;
+    T value = T.init;
 
     if(bytes.length >= T.sizeof)
     {
@@ -266,7 +266,7 @@ unittest
  *
  * In this case provided bytes DO NOT
  * match the given integral to-type
- * and therefore `0` is returned
+ * and therefore to-type.init is returned
  */
 unittest
 {

--- a/source/niknaks/bits.d
+++ b/source/niknaks/bits.d
@@ -258,3 +258,27 @@ unittest
         assert(to == 256);
     }
 }
+
+/**
+ * Tests taking a byte array and then
+ * decoding it into the requested type
+ * by using `bytesToIntegral!(T)(ubyte[])`
+ *
+ * In this case provided bytes DO NOT
+ * match the given integral to-type
+ */
+unittest
+{
+    version(LittleEndian)
+    {
+        ubyte[] bytes = [1];
+        ushort to = bytesToIntegral!(ushort)(bytes);
+        assert(to == 1);
+    }
+    else version(BigEndian)
+    {
+        ubyte[] bytes = [1];
+        ushort to = bytesToIntegral!(ushort)(bytes);
+        assert(to == 256);
+    }
+}

--- a/source/niknaks/bits.d
+++ b/source/niknaks/bits.d
@@ -266,6 +266,7 @@ unittest
  *
  * In this case provided bytes DO NOT
  * match the given integral to-type
+ * and therefore `0` is returned
  */
 unittest
 {
@@ -273,12 +274,12 @@ unittest
     {
         ubyte[] bytes = [1];
         ushort to = bytesToIntegral!(ushort)(bytes);
-        assert(to == 1);
+        assert(to == 0);
     }
     else version(BigEndian)
     {
         ubyte[] bytes = [1];
         ushort to = bytesToIntegral!(ushort)(bytes);
-        assert(to == 256);
+        assert(to == 0);
     }
 }

--- a/source/niknaks/bits.d
+++ b/source/niknaks/bits.d
@@ -225,14 +225,14 @@ unittest
  */
 public T bytesToIntegral(T)(ubyte[] bytes) if(__traits(isIntegral, T))
 {
-    T value = T.init;
-
     if(bytes.length >= T.sizeof)
     {
-        value = *cast(T*)bytes.ptr;
+        return *cast(T*)bytes.ptr;
     }
-
-    return value;
+    else
+    {
+        return T.init;
+    }
 }
 
 /**


### PR DESCRIPTION
## Purpose

From a byte array to given type, more clear. We call it `bytesToIntegral!(toIntegralType)(ubyte)`.

## Todo :writing_hand: 

- [x] Code documentation
- [x] Unit testing
    - [x] On ARM BigEndian
    - [x] On x86 LittleEndian