### PR TITLE
Array dumping updates

### DIFF
--- a/source/niknaks/debugging.d
+++ b/source/niknaks/debugging.d
@@ -49,15 +49,16 @@ public string genTabs(size_t count)
 template dumpArray(alias array)
 if(isArray!(typeof(array)))
 {
-
+    // Get the type of the array
     private alias symbolType = typeof(array);
     pragma(msg, "Symboltype: ", symbolType);
 
+    // Get the arrays'e element type
     private alias elementType = ForeachType!(symbolType);
     pragma(msg, "Element type: ", elementType);
 
+    // Get the array's name as a string
     private string ident = __traits(identifier, array);
-
 
     /** 
      * Dumps the array within the provided boundries

--- a/source/niknaks/debugging.d
+++ b/source/niknaks/debugging.d
@@ -114,6 +114,52 @@ if(isArray!(typeof(array)))
 }
 
 /**
+ * Test dumping an array of integers
+ */
+unittest
+{
+    int[] test = [1,2,3];
+    writeln("Should have 3 things (BEGIN)");
+    write(dumpArray!(test));
+    writeln("Should have 3 things (END)");
+}
+
+/**
+ * Test dumping an array of integers
+ * with custom bounds
+ */
+unittest
+{
+    int[] test = [1,2,3];
+    writeln("Should have nothing (BEGIN)");
+    write(dumpArray!(test)(0, 0));
+    writeln("Should have nothing (END)");
+}
+
+/**
+ * Test dumping an array of integers
+ * with custom bounds
+ */
+unittest
+{
+    int[] test = [1,2,3];
+    writeln("Should have 2 (BEGIN)");
+    write(dumpArray!(test)(1, 2));
+    writeln("Should have 2 (END)");
+}
+
+/**
+ * Test dumping an array of integer
+ * arrays
+ */
+unittest
+{
+    int[][] test = [ [1,2,3], [4,5,6]];
+    write(dumpArray!(test));
+}
+
+
+/**
  * Test dumping an array of an array of
  * integer arrays
  */
@@ -133,16 +179,6 @@ unittest
 }
 
 /**
- * Tests the array-name dumping
- */
-unittest
-{
-    int[] bruh = [1,2,3];
-    string g = dumpArray!(bruh)();
-    writeln(g);
-}
-
-/**
  * Tests out the compile-time component-type
  * detection of `string` in any array of them
  */
@@ -150,6 +186,16 @@ unittest
 {
     string[] stringArray = ["Hello", "world"];
     writeln(dumpArray!(stringArray));
+}
+
+/**
+ * Tests the array-name dumping
+ */
+unittest
+{
+    int[] bruh = [1,2,3];
+    string g = dumpArray!(bruh)();
+    writeln(g);
 }
 
 /** 
@@ -206,49 +252,3 @@ version(unittest)
 {
     import std.stdio : writeln, write;
 }
-
-/**
- * Test dumping an array of integers
- */
-unittest
-{
-    int[] test = [1,2,3];
-    writeln("Should have 3 things (BEGIN)");
-    write(dumpArray!(test));
-    writeln("Should have 3 things (END)");
-}
-
-/**
- * Test dumping an array of integers
- * with custom bounds
- */
-unittest
-{
-    int[] test = [1,2,3];
-    writeln("Should have nothing (BEGIN)");
-    write(dumpArray!(test)(0, 0));
-    writeln("Should have nothing (END)");
-}
-
-/**
- * Test dumping an array of integers
- * with custom bounds
- */
-unittest
-{
-    int[] test = [1,2,3];
-    writeln("Should have 2 (BEGIN)");
-    write(dumpArray!(test)(1, 2));
-    writeln("Should have 2 (END)");
-}
-
-/**
- * Test dumping an array of integer
- * arrays
- */
-unittest
-{
-    int[][] test = [ [1,2,3], [4,5,6]];
-    write(dumpArray!(test));
-}
-

--- a/source/niknaks/debugging.d
+++ b/source/niknaks/debugging.d
@@ -140,19 +140,6 @@ if(isArray!(typeof(array)))
     {
         return dumpArray!(array)(0, array.length);
     }
-    return output;
-}
-
-/** 
- * Dumps a given array 
- *
- * Params:
- *   array = the array
- * Returns: the formatted dump text
- */
-public string dumpArray(T)(T[] array)
-{
-    return dumpArray(array, 0, array.length);
 }
 
 /**
@@ -288,9 +275,4 @@ private string dumpArray_rec(T)(T[] array, size_t start, size_t end, size_t dept
     }
 
     return output;
-}
-
-version(unittest)
-{
-    import std.stdio : writeln, write;
 }

--- a/source/niknaks/debugging.d
+++ b/source/niknaks/debugging.d
@@ -46,7 +46,7 @@ public string genTabs(size_t count)
  * Params:
  *   array = the array to dump
  */
-template dumpArray2(alias array)
+template dumpArray(alias array)
 if(isArray!(typeof(array)))
 {
 
@@ -67,7 +67,7 @@ if(isArray!(typeof(array)))
      *   end = ending index
      * Returns: the formatted dump text
      */
-    public string dumpArray2(size_t start, size_t end, size_t depth = 0)
+    public string dumpArray(size_t start, size_t end, size_t depth = 0)
     {
         // String out
         string output;
@@ -107,9 +107,9 @@ if(isArray!(typeof(array)))
      *
      * Returns: the formatted dump text
      */
-    public string dumpArray2()
+    public string dumpArray()
     {
-        return dumpArray2!(array)(0, array.length);
+        return dumpArray!(array)(0, array.length);
     }
 }
 
@@ -117,7 +117,7 @@ if(isArray!(typeof(array)))
 unittest
 {
     int[] bruh = [1,2,3];
-    string g = dumpArray2!(bruh)();
+    string g = dumpArray!(bruh)();
     writeln(g);
 }
 
@@ -128,7 +128,7 @@ unittest
 unittest
 {
     string[] stringArray = ["Hello", "world"];
-    writeln(dumpArray2!(stringArray));
+    writeln(dumpArray!(stringArray));
 }
 
 /** 
@@ -181,17 +181,6 @@ private string dumpArray_rec(T)(T[] array, size_t start, size_t end, size_t dept
     return output;
 }
 
-/** 
- * Dumps a given array 
- *
- * Params:
- *   array = the array
- * Returns: the formatted dump text
- */
-public string dumpArray(T)(T[] array)
-{
-    return dumpArray(array, 0, array.length);
-}
 
 version(unittest)
 {
@@ -205,7 +194,7 @@ unittest
 {
     int[] test = [1,2,3];
     writeln("Should have 3 things (BEGIN)");
-    write(dumpArray2!(test));
+    write(dumpArray!(test));
     writeln("Should have 3 things (END)");
 }
 
@@ -217,7 +206,7 @@ unittest
 {
     int[] test = [1,2,3];
     writeln("Should have nothing (BEGIN)");
-    write(dumpArray2!(test)(0, 0));
+    write(dumpArray!(test)(0, 0));
     writeln("Should have nothing (END)");
 }
 
@@ -229,7 +218,7 @@ unittest
 {
     int[] test = [1,2,3];
     writeln("Should have 2 (BEGIN)");
-    write(dumpArray2!(test)(1, 2));
+    write(dumpArray!(test)(1, 2));
     writeln("Should have 2 (END)");
 }
 
@@ -240,7 +229,7 @@ unittest
 unittest
 {
     int[][] test = [ [1,2,3], [4,5,6]];
-    write(dumpArray2!(test));
+    write(dumpArray!(test));
 }
 
 /**
@@ -259,5 +248,5 @@ unittest
             [6,7]
         ]
     ];
-    write(dumpArray2!(test));
+    write(dumpArray!(test));
 }

--- a/source/niknaks/debugging.d
+++ b/source/niknaks/debugging.d
@@ -109,7 +109,7 @@ unittest
 unittest
 {
     string[] stringArray = ["Hello", "world"];
-    writeln(stringArray.dumpArray);
+    writeln(dumpArray2!(stringArray));
 }
 
 /** 
@@ -183,7 +183,7 @@ unittest
 {
     int[] test = [1,2,3];
     writeln("Should have 3 things (BEGIN)");
-    write(dumpArray(test));
+    write(dumpArray2!(test));
     writeln("Should have 3 things (END)");
 }
 
@@ -195,7 +195,7 @@ unittest
 {
     int[] test = [1,2,3];
     writeln("Should have nothing (BEGIN)");
-    write(dumpArray(test, 0, 0));
+    write(dumpArray2!(test)(0, 0));
     writeln("Should have nothing (END)");
 }
 
@@ -207,7 +207,7 @@ unittest
 {
     int[] test = [1,2,3];
     writeln("Should have 2 (BEGIN)");
-    write(dumpArray(test, 1, 2));
+    write(dumpArray2!(test)(1, 2));
     writeln("Should have 2 (END)");
 }
 
@@ -218,7 +218,7 @@ unittest
 unittest
 {
     int[][] test = [ [1,2,3], [4,5,6]];
-    write(dumpArray(test));
+    write(dumpArray2!(test));
 }
 
 /**
@@ -237,5 +237,5 @@ unittest
             [6,7]
         ]
     ];
-    write(dumpArray(test));
+    write(dumpArray2!(test));
 }

--- a/source/niknaks/debugging.d
+++ b/source/niknaks/debugging.d
@@ -86,7 +86,7 @@ if(isArray!(typeof(array)))
                 output ~= textOut~"\n";
 
 
-                output ~= dumpArray(array[i], 0, array[i].length, depth+1);
+                output ~= dumpArray_rec(array[i], 0, array[i].length, depth+1);
             }
             else
             {
@@ -134,13 +134,16 @@ unittest
 /** 
  * Dumps a given array within the provided boundries
  *
+ * This method is used internally for the recursive
+ * call as it won't work with the template.
+ *
  * Params:
  *   array = the array
  *   start = beginning index
  *   end = ending index
  * Returns: the formatted dump text
  */
-public string dumpArray(T)(T[] array, size_t start, size_t end, size_t depth = 0)
+private string dumpArray_rec(T)(T[] array, size_t start, size_t end, size_t depth = 0)
 {
     // String out
     string output;
@@ -162,7 +165,7 @@ public string dumpArray(T)(T[] array, size_t start, size_t end, size_t depth = 0
             output ~= textOut~"\n";
 
 
-            output ~= dumpArray(array[i], 0, array[i].length, depth+1);
+            output ~= dumpArray_rec(array[i], 0, array[i].length, depth+1);
         }
         else
         {

--- a/source/niknaks/debugging.d
+++ b/source/niknaks/debugging.d
@@ -113,6 +113,24 @@ if(isArray!(typeof(array)))
     }
 }
 
+/**
+ * Test dumping an array of an array of
+ * integer arrays
+ */
+unittest
+{
+    int[][][] test = [
+        [   [1,2],
+            [3,4]
+        ],
+        
+        [
+            [4,5],
+            [6,7]
+        ]
+    ];
+    write(dumpArray!(test));
+}
 
 /**
  * Tests the array-name dumping
@@ -234,21 +252,3 @@ unittest
     write(dumpArray!(test));
 }
 
-/**
- * Test dumping an array of an array of
- * integer arrays
- */
-unittest
-{
-    int[][][] test = [
-        [   [1,2],
-            [3,4]
-        ],
-        
-        [
-            [4,5],
-            [6,7]
-        ]
-    ];
-    write(dumpArray!(test));
-}

--- a/source/niknaks/debugging.d
+++ b/source/niknaks/debugging.d
@@ -3,7 +3,7 @@
  */
 module niknaks.debugging;
 
-import std.traits : isArray;
+import std.traits : isArray, ForeachType;
 import std.conv : to;
 
 /** 
@@ -40,16 +40,67 @@ public string genTabs(size_t count)
     return genX(count, "\t");
 }
 
-// public string dumpArray2(alias T = g, K)(K g)
-// {
-//     return ""~thing;
-// }
+template dumpArray2(alias array)
+if(isArray!(typeof(array)))
+{
 
-// unittest
-// {
-//     int[] bruh = [1,2,3];
-//     string g = dumpArray2(bruh);
-// }
+    private alias symbolType = typeof(array);
+    pragma(msg, "Symboltype: ", symbolType);
+
+    private alias elementType = ForeachType!(symbolType);
+    pragma(msg, "Element type: ", elementType);
+
+    private string ident = __traits(identifier, array);
+
+
+    public string dumpArray2(size_t start, size_t end, size_t depth = 0)
+    {
+        // String out
+        string output;
+
+        for(size_t i = start; i < end; i++)
+        {
+            string textOut;
+
+            static if(isArray!(elementType) && !__traits(isSame, elementType, string))
+            {
+                textOut = (depth ? "":ident)~"["~to!(string)(i)~"] = ...";
+
+                // Tab by depth
+                textOut = genTabs(depth)~textOut;
+
+                output ~= textOut~"\n";
+
+
+                output ~= dumpArray(array[i], 0, array[i].length, depth+1);
+            }
+            else
+            {
+                textOut = (depth ? "":ident)~"["~to!(string)(i)~"] = "~to!(string)(array[i]);
+
+                // Tab by depth
+                textOut = genTabs(depth)~textOut;
+
+                output ~= textOut~"\n";
+            }
+        }
+
+        return output;
+    }
+
+    public string dumpArray2()
+    {
+        return dumpArray2!(array)(0, array.length);
+    }
+}
+
+
+unittest
+{
+    int[] bruh = [1,2,3];
+    string g = dumpArray2!(bruh)();
+    writeln(g);
+}
 
 /**
  * Tests out the compile-time component-type

--- a/source/niknaks/debugging.d
+++ b/source/niknaks/debugging.d
@@ -40,6 +40,27 @@ public string genTabs(size_t count)
     return genX(count, "\t");
 }
 
+// public string dumpArray2(alias T = g, K)(K g)
+// {
+//     return ""~thing;
+// }
+
+// unittest
+// {
+//     int[] bruh = [1,2,3];
+//     string g = dumpArray2(bruh);
+// }
+
+/**
+ * Tests out the compile-time component-type
+ * detection of `string` in any array of them
+ */
+unittest
+{
+    string[] stringArray = ["Hello", "world"];
+    writeln(stringArray.dumpArray);
+}
+
 /** 
  * Dumps a given array within the provided boundries
  *
@@ -61,7 +82,7 @@ public string dumpArray(T)(T[] array, size_t start, size_t end, size_t depth = 0
     {
         string textOut;
 
-        static if(isArray!(T))
+        static if(isArray!(T) && !__traits(isSame, T, string))
         {
             textOut = (depth ? "":ident)~"["~to!(string)(i)~"] = ...";
 

--- a/source/niknaks/debugging.d
+++ b/source/niknaks/debugging.d
@@ -40,6 +40,12 @@ public string genTabs(size_t count)
     return genX(count, "\t");
 }
 
+/** 
+ * Dumps the provided array
+ *
+ * Params:
+ *   array = the array to dump
+ */
 template dumpArray2(alias array)
 if(isArray!(typeof(array)))
 {
@@ -53,6 +59,14 @@ if(isArray!(typeof(array)))
     private string ident = __traits(identifier, array);
 
 
+    /** 
+     * Dumps the array within the provided boundries
+     *
+     * Params:
+     *   start = beginning index
+     *   end = ending index
+     * Returns: the formatted dump text
+     */
     public string dumpArray2(size_t start, size_t end, size_t depth = 0)
     {
         // String out
@@ -88,6 +102,11 @@ if(isArray!(typeof(array)))
         return output;
     }
 
+    /** 
+     * Dumps the entire array
+     *
+     * Returns: the formatted dump text
+     */
     public string dumpArray2()
     {
         return dumpArray2!(array)(0, array.length);

--- a/source/niknaks/debugging.d
+++ b/source/niknaks/debugging.d
@@ -114,6 +114,9 @@ if(isArray!(typeof(array)))
 }
 
 
+/**
+ * Tests the array-name dumping
+ */
 unittest
 {
     int[] bruh = [1,2,3];
@@ -180,7 +183,6 @@ private string dumpArray_rec(T)(T[] array, size_t start, size_t end, size_t dept
 
     return output;
 }
-
 
 version(unittest)
 {


### PR DESCRIPTION
## Purpose

- [x] Dumping final compoent `T` which is a `string` must not be template-recursed on
- [x] Symbol based `alias` array naming

## Docs

- [x] Document 
- [x] Ensure aliases and important things are private

## Unit tests

- [x] Test `string` edge case handling
- [x] Test new `dumpArray2!(alias)` template