### PR TITLE
⚡ Feature: Result type

### DIFF
--- a/source/niknaks/functional.d
+++ b/source/niknaks/functional.d
@@ -326,7 +326,6 @@ public struct Result(Okay, Error)
 	}
 }
 
-
 /** 
  * Constructs a new `Result` with the
  * status set to okay and with the

--- a/source/niknaks/functional.d
+++ b/source/niknaks/functional.d
@@ -299,27 +299,57 @@ public struct Result(Okay, Error)
 		this.isSucc = isSucc;
 	}
 
+	/** 
+	 * Retuns the okay value
+	 *
+	 * Returns: the value
+	 */
 	public Okay ok()
 	{
 		return this.okay_val;
 	}
 
+	/** 
+	 * Returns the error value
+	 *
+	 * Returns: the value
+	 */
 	public Error error()
 	{
 		return this.error_val;
 	}
 
+	/** 
+	 * Returns the okayness of
+	 * this result
+	 *
+	 * See_Also: `is_okay`
+	 * Returns: a boolean
+	 */
 	public bool opCast(T)()
 	if(__traits(isSame, T, bool))
 	{
 		return is_okay();
 	}
 
+	/** 
+	 * Check if is okay
+	 *
+	 * Returns: `true` if
+	 * okay, `false` otherwise
+	 */
 	public bool is_okay()
 	{
 		return this.isSucc == true;
 	}
 
+	/** 
+	 * Check if is erroneous
+	 *
+	 * Returns: `true` if
+	 * erroneous, `false`
+	 * otherwise
+	 */
 	public bool is_error()
 	{
 		return this.isSucc == false;

--- a/source/niknaks/functional.d
+++ b/source/niknaks/functional.d
@@ -280,6 +280,9 @@ unittest
 	}
 }
 
+/** 
+ * A result type
+ */
 @safe @nogc
 public struct Result(Okay, Error)
 {
@@ -324,6 +327,20 @@ public struct Result(Okay, Error)
 }
 
 
+/** 
+ * Constructs a new `Result` with the
+ * status set to okay and with the
+ * provided value.
+ *
+ * If you don't specify the type
+ * of the error value for this
+ * then it is assumed to be the
+ * same as the okay type.
+ *
+ * Params:
+ *   okayVal = the okay value
+ * Returns: a `Result`
+ */
 @safe @nogc
 public static Result!(OkayType, ErrorType) ok(OkayType, ErrorType = OkayType)(OkayType okayVal)
 {
@@ -333,6 +350,20 @@ public static Result!(OkayType, ErrorType) ok(OkayType, ErrorType = OkayType)(Ok
 	return result;
 }
 
+/** 
+ * Constructs a new `Result` with the
+ * status set to error and with the
+ * provided value.
+ *
+ * If you don't specify the type
+ * of the okay value for this
+ * then it is assumed to be the
+ * same as the error type.
+ *
+ * Params:
+ *   errorVal = the error value
+ * Returns: a `Result`
+ */
 @safe @nogc
 public static Result!(OkayType, ErrorType) error(ErrorType, OkayType = ErrorType)(ErrorType errorVal)
 {

--- a/source/niknaks/functional.d
+++ b/source/niknaks/functional.d
@@ -342,11 +342,10 @@ public static Result!(OkayType, ErrorType) error(ErrorType, OkayType = ErrorType
 	return result;
 }
 
-version(unittest)
-{
-	import std.traits;
-}
-
+/**
+ * Tests the usage of okay
+ * result types
+ */
 unittest
 {
 	auto a = ok("A successful result");
@@ -373,6 +372,10 @@ unittest
 	static assert(__traits(isSame, typeof(b.error_val), Exception));
 }
 
+/**
+ * Tests the usage of error
+ * result types
+ */
 unittest
 {
 	auto a = error(new Exception("A failed result"));

--- a/source/niknaks/functional.d
+++ b/source/niknaks/functional.d
@@ -280,6 +280,7 @@ unittest
 	}
 }
 
+@safe @nogc
 public struct Result(Okay, Error)
 {
 	private Okay okay_val;
@@ -323,7 +324,7 @@ public struct Result(Okay, Error)
 }
 
 
-
+@safe @nogc
 public static Result!(OkayType, ErrorType) ok(OkayType, ErrorType = OkayType)(OkayType okayVal)
 {
 	Result!(OkayType, ErrorType) result = Result!(OkayType, ErrorType)(true);
@@ -332,6 +333,7 @@ public static Result!(OkayType, ErrorType) ok(OkayType, ErrorType = OkayType)(Ok
 	return result;
 }
 
+@safe @nogc
 public static Result!(OkayType, ErrorType) error(ErrorType, OkayType = ErrorType)(ErrorType errorVal)
 {
 	Result!(OkayType, ErrorType) result = Result!(OkayType, ErrorType)(false);


### PR DESCRIPTION
Add a `Result` type which is also `@safe` and `@nogc`.

- [x] Implemented
- [x] Tested
- [x] Documented